### PR TITLE
Fix linter issues

### DIFF
--- a/src/concurrency/concurrency_manager.rs
+++ b/src/concurrency/concurrency_manager.rs
@@ -6,7 +6,7 @@ use crate::db::db::{TxnLink, TxnMap};
 use crate::db::request_queue::TaskQueueRequest;
 use crate::execute::request::{Command, Request};
 use crate::latch_manager::latch_manager::{LatchGuard, LatchManager};
-use crate::lock_table::lock_table::{LockTable, LockTableGuardLink, UpdateLock};
+use crate::lock_table::lock_table::{LockTable, LockTableGuardLink, UpdateLock, WaitForGuardError};
 use crate::storage::mvcc::KVStore;
 use crate::storage::Key;
 
@@ -53,8 +53,8 @@ impl ConcurrencyManager {
                 let wait_res = self.lock_table.wait_for(lock_guard).await;
                 if let Err(err) = wait_res {
                     match err {
-                        TxnAborted => return Err(SequenceReqError::TxnAborted),
-                        TxnCommitted => return Err(SequenceReqError::TxnCommitted),
+                        WaitForGuardError::TxnAborted => return Err(SequenceReqError::TxnAborted),
+                        WaitForGuardError::TxnCommitted => return Err(SequenceReqError::TxnCommitted),
                     }
                 };
 

--- a/src/execute/executor.rs
+++ b/src/execute/executor.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc::Sender;
 use uuid::Uuid;
 
 use crate::{
-    concurrency::concurrency_manager::{ConcurrencyManager, Guard},
+    concurrency::concurrency_manager::{ConcurrencyManager, Guard, SequenceReqError},
     db::{
         db::{TxnLink, TxnMap},
         request_queue::TaskQueueRequest,
@@ -71,8 +71,8 @@ impl Executor {
 
             if let Err(err) = &guard {
                 match err {
-                    TxnAborted => return ExecuteResult::Err(ExecuteError::TxnAborted),
-                    TxnCommitted => return ExecuteResult::Err(ExecuteError::TxnCommitted),
+                    &SequenceReqError::TxnAborted => return ExecuteResult::Err(ExecuteError::TxnAborted),
+                    &SequenceReqError::TxnCommitted => return ExecuteResult::Err(ExecuteError::TxnCommitted),
                 }
             }
 


### PR DESCRIPTION
**Issue**
Running `cargo build` results in errors due to [bindings_with_variant_name](https://doc.rust-lang.org/beta/nightly-rustc/rustc_lint/builtin/static.BINDINGS_WITH_VARIANT_NAME.html) on **Mac M1**

**Error log**
First Instance:
```
error[E0170]: pattern binding `TxnAborted` is named the same as one of the variants of the type `lock_table::lock_table::WaitForGuardError`
  --> src/concurrency/concurrency_manager.rs:56:25
   |
56 |                         TxnAborted => return Err(SequenceReqError::TxnAborted),
   |                         ^^^^^^^^^^ help: to match on the variant, qualify the path: `lock_table::lock_table::WaitForGuardError::TxnAborted`
   |
   = note: `#[deny(bindings_with_variant_name)]` on by default

error[E0170]: pattern binding `TxnCommitted` is named the same as one of the variants of the type `lock_table::lock_table::WaitForGuardError`
  --> src/concurrency/concurrency_manager.rs:57:25
   |
57 |                         TxnCommitted => return Err(SequenceReqError::TxnCommitted),
   |                         ^^^^^^^^^^^^ help: to match on the variant, qualify the path: `lock_table::lock_table::WaitForGuardError::TxnCommitted`
```

Second Instance
```
error[E0170]: pattern binding `TxnAborted` is named the same as one of the variants of the type `concurrency::concurrency_manager::SequenceReqError`
  --> src/execute/executor.rs:74:21
   |
74 |                     TxnAborted => return ExecuteResult::Err(ExecuteError::TxnAborted),
   |                     ^^^^^^^^^^ help: to match on the variant, qualify the path: `concurrency::concurrency_manager::SequenceReqError::TxnAborted`

error[E0170]: pattern binding `TxnCommitted` is named the same as one of the variants of the type `concurrency::concurrency_manager::SequenceReqError`
  --> src/execute/executor.rs:75:21
   |
75 |                     TxnCommitted => return ExecuteResult::Err(ExecuteError::TxnCommitted),
   |                     ^^^^^^^^^^^^ help: to match on the variant, qualify the path: `concurrency::concurrency_manager::SequenceReqError::TxnCommitted`
```

**Change**
Adding explicit import for enum values