### PR TITLE
Running cargo fix

### DIFF
--- a/src/concurrency/concurrency_manager.rs
+++ b/src/concurrency/concurrency_manager.rs
@@ -97,15 +97,9 @@ impl ConcurrencyManager {
 }
 
 mod test {
-    use std::thread;
+    
 
-    use tokio::{
-        sync::{
-            mpsc::{self, channel, Receiver, Sender},
-            Mutex,
-        },
-        time::{self, Duration},
-    };
+    
 
     #[tokio::test]
     async fn test_select() {

--- a/src/db/db.rs
+++ b/src/db/db.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     future::Future,
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, RwLock},
 };
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -277,8 +277,8 @@ impl InternalDB {
 
     pub async fn read_without_txn<T: DeserializeOwned>(
         &self,
-        key: &str,
-        timestamp: Timestamp,
+        _key: &str,
+        _timestamp: Timestamp,
     ) -> T {
         todo!()
     }
@@ -311,7 +311,7 @@ impl InternalDB {
             metadata: request_metadata,
             request_union: txn_request,
         };
-        let response = self
+        let _response = self
             .executor
             .execute_request_with_concurrency_retries(request)
             .await;

--- a/src/db/db_test.rs
+++ b/src/db/db_test.rs
@@ -2,9 +2,9 @@ mod test {
 
     // simple tests that involve writes and reads
     mod single_txn_simple_test {
-        use std::sync::Arc;
+        
 
-        use crate::db::db::{Timestamp, DB};
+        
 
         #[tokio::test]
         async fn two_writes_with_different_keys() {
@@ -43,11 +43,11 @@ mod test {
         mod write_read {
             mod uncommitted_intent_has_lower_timestamp {
 
-                use std::sync::Arc;
+                
 
-                use tokio::time::{self, sleep, Duration};
+                
 
-                use crate::db::db::{Timestamp, DB};
+                
 
                 #[tokio::test]
                 async fn read_waits_for_uncommitted_write() {
@@ -76,9 +76,9 @@ mod test {
             // A read running into an uncommitted intent with a higher timestamp ignores the
             // intent and does not need to wait.
             mod uncommitted_intent_has_higher_timestamp {
-                use std::sync::Arc;
+                
 
-                use crate::db::db::{Timestamp, DB};
+                
 
                 #[tokio::test]
                 async fn ignores_intent_with_higher_timestamp() {
@@ -100,15 +100,9 @@ mod test {
         // A write running into a committed value with a higher tiestamp will bump its timestamp.
         mod write_write {
             mod run_into_uncommitted_intent {
-                use std::sync::Arc;
+                
 
-                use crate::{
-                    db::db::{CommitTxnResult, Timestamp, DB},
-                    hlc::{
-                        clock::{Clock, ManualClock},
-                        timestamp::Timestamp as HLCTimestamp,
-                    },
-                };
+                
 
                 #[tokio::test]
                 async fn write_waits_for_uncommitted_write() {
@@ -152,15 +146,9 @@ mod test {
             }
 
             mod run_into_committed_intent {
-                use std::sync::Arc;
+                
 
-                use crate::{
-                    db::db::{CommitTxnResult, Timestamp, DB},
-                    hlc::{
-                        clock::{Clock, ManualClock},
-                        timestamp::Timestamp as HLCTimestamp,
-                    },
-                };
+                
 
                 #[tokio::test]
                 async fn bump_write_timestamp_before_committing() {
@@ -209,9 +197,9 @@ mod test {
          * the writeTimestamp is bumped
          */
         mod read_write {
-            use std::sync::Arc;
+            
 
-            use crate::db::db::{CommitTxnResult, Timestamp, DB};
+            
 
             #[tokio::test]
             async fn bump_write_timestamp_before_committing() {
@@ -247,14 +235,14 @@ mod test {
     }
 
     mod read_refresh {
-        use std::sync::Arc;
+        
 
-        use tokio::time::{self, sleep, Duration};
+        
 
         mod read_refresh_success {
-            use std::sync::Arc;
+            
 
-            use crate::db::db::{CommitTxnResult, Timestamp, DB};
+            
 
             #[tokio::test]
             async fn read_refresh_from_write_write_conflict() {
@@ -290,9 +278,9 @@ mod test {
         // Advancing a transaction read timestamp from ta to tb is possible
         // if we can prove that none of the data
         mod read_refresh_failure {
-            use std::sync::Arc;
+            
 
-            use crate::db::db::{CommitTxnResult, Timestamp, DB};
+            
 
             #[tokio::test]
             async fn read_refresh_failure() {
@@ -334,7 +322,7 @@ mod test {
     }
 
     mod abort_txn {
-        use crate::db::db::{Timestamp, DB};
+        
 
         #[tokio::test]
         async fn read_write_after_abort_transaction() {
@@ -359,12 +347,9 @@ mod test {
     }
 
     mod deadlock {
-        use std::sync::Arc;
+        
 
-        use crate::{
-            db::db::{CommitTxnResult, Timestamp, DB},
-            storage::str_to_key,
-        };
+        
 
         #[tokio::test]
         async fn conflicting_writes() {
@@ -470,9 +455,9 @@ mod test {
     }
 
     mod run_txn {
-        use std::sync::Arc;
+        
 
-        use crate::db::db::{Timestamp, DB};
+        
 
         #[tokio::test]
         async fn reading_its_txn_own_write() {

--- a/src/db/request_queue.rs
+++ b/src/db/request_queue.rs
@@ -1,9 +1,7 @@
 use std::{
     sync::{
-        mpsc::{self},
         Arc,
     },
-    thread,
 };
 
 use tokio::{
@@ -85,7 +83,7 @@ impl TaskQueue {
                                     metadata: request_metadata,
                                     request_union: txn_request,
                                 };
-                                let response = executor_cloned
+                                let _response = executor_cloned
                                     .execute_request_with_concurrency_retries(request)
                                     .await
                                     .unwrap();

--- a/src/execute/executor.rs
+++ b/src/execute/executor.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, RwLock};
 
 use tokio::sync::mpsc::Sender;
-use uuid::Uuid;
+
 
 use crate::{
     concurrency::concurrency_manager::{ConcurrencyManager, Guard, SequenceReqError},
@@ -118,7 +118,7 @@ impl Executor {
         // If the txn has aborted, remove the txn record
     }
 
-    pub async fn execute_write_request(&self, request: &Request, guard: &Guard) -> ResponseResult {
+    pub async fn execute_write_request(&self, request: &Request, _guard: &Guard) -> ResponseResult {
         // finds the max read timestamp from timestamp oracle for the spans
         // and bump the write timestamp if necessary
         let spans = request
@@ -154,7 +154,7 @@ impl Executor {
     pub async fn execute_read_only_request(
         &self,
         request: &Request,
-        guard: &Guard,
+        _guard: &Guard,
     ) -> ResponseResult {
         let result = request
             .request_union

--- a/src/execute/request.rs
+++ b/src/execute/request.rs
@@ -1,6 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
-    default,
+    collections::{HashSet},
 };
 
 use async_trait::async_trait;
@@ -10,16 +9,14 @@ use uuid::Uuid;
 use crate::{
     db::db::TxnLink,
     hlc::timestamp::Timestamp,
-    latch_manager::latch_interval_btree::{NodeKey, Range},
+    latch_manager::latch_interval_btree::{Range},
     lock_table::lock_table::{AbortUpdateLock, CommitUpdateLock, UpdateLock},
     storage::{
-        mvcc::{KVStore, MVCCGetParams, WriteIntentError},
+        mvcc::{MVCCGetParams},
         mvcc_key::{create_intent_key, MVCCKey},
-        str_to_key,
-        txn::{TransactionStatus, Txn, TxnIntent, TxnMetadata},
+        txn::{TransactionStatus, TxnIntent},
         Key, Value,
     },
-    StorageResult,
 };
 
 use super::executor::Executor;
@@ -64,7 +61,7 @@ pub enum RequestUnion {
 }
 
 // TODO: Does this need a timestamp in there?
-pub type SpanSet<K: NodeKey> = Vec<Range<K>>;
+pub type SpanSet<K> = Vec<Range<K>>;
 
 pub fn dedupe_spanset(v: &mut SpanSet<Key>) {
     // note the Copy constraint

--- a/src/interval/interval_tree.rs
+++ b/src/interval/interval_tree.rs
@@ -1,7 +1,6 @@
-use std::ops::Deref;
+
 
 use crate::{
-    hlc::timestamp::Timestamp,
     llrb::llrb::{NodeKey, NodeValue, RbTree, NIL},
 };
 
@@ -106,14 +105,9 @@ impl<K: NodeKey, V: NodeValue> IntervalTree<K, V> {
 mod tests {
 
     mod get_overlap {
-        use std::{
-            borrow::{Borrow, BorrowMut},
-            cell::RefCell,
-            ops::Deref,
-            rc::{Rc, Weak},
-        };
+        
 
-        use crate::interval::interval_tree::{IntervalTree, RangeValue, Test};
+        
 
         #[test]
         fn test_overlap() {

--- a/src/latch_manager/latch_interval_btree.rs
+++ b/src/latch_manager/latch_interval_btree.rs
@@ -1,13 +1,10 @@
 use std::{
-    borrow::{Borrow, BorrowMut},
-    cell::RefCell,
-    rc::Rc,
+    borrow::{Borrow},
     sync::{Arc, Mutex, RwLock, Weak},
 };
 
 use tokio::{
-    sync::mpsc::{self, channel, Receiver, Sender},
-    time::{self, Duration},
+    sync::mpsc::{self, Receiver, Sender},
 };
 
 use crate::storage::{mvcc_key::MVCCKey, Key};
@@ -149,7 +146,7 @@ impl<K: NodeKey> Node<K> {
                 let mut keys = internal.keys.write().unwrap();
                 keys[idx] = new_key;
             }
-            Node::Leaf(leaf) => {
+            Node::Leaf(_leaf) => {
                 panic!("Currently don't support updating key for leaf node")
             }
         }
@@ -619,7 +616,7 @@ impl<K: NodeKey> LeafNode<K> {
      */
     pub fn steal_from_right_leaf_sibling(
         &self,
-        key_to_delete: &K,
+        _key_to_delete: &K,
         right_latch_node: LatchNode<K>,
         parent: &InternalNode<K>,
         edge_idx: usize,
@@ -647,7 +644,7 @@ impl<K: NodeKey> LeafNode<K> {
 
     pub fn steal_from_left_leaf_sibling(
         &self,
-        key_to_delete: &K,
+        _key_to_delete: &K,
         left_latch_node: LatchNode<K>,
         parent: &InternalNode<K>,
         edge_idx: usize,

--- a/src/latch_manager/latch_interval_btree_test.rs
+++ b/src/latch_manager/latch_interval_btree_test.rs
@@ -1,8 +1,6 @@
 mod Test {
     use std::{
         borrow::Borrow,
-        cell::RefCell,
-        process::Child,
         rc::Rc,
         sync::{Arc, RwLock},
     };
@@ -220,7 +218,7 @@ mod Test {
     fn print_tree_internal<K: NodeKey>(link: &NodeLink<K>, depth: usize) {
         let edge = link.read().unwrap().clone();
         if let Some(ref latch) = edge {
-            let node = latch.as_ref();
+            let _node = latch.as_ref();
             let guard = latch.read().unwrap();
             match &*guard {
                 Node::Internal(ref node) => {
@@ -252,7 +250,7 @@ mod Test {
         let test_leaves = get_all_test_leaves(test_node);
         let leaves = get_all_leaf_nodes(node.clone());
         assert_eq!(test_leaves.len(), leaves.len());
-        for (idx, current_test_node) in test_leaves.iter().enumerate() {
+        for (idx, _current_test_node) in test_leaves.iter().enumerate() {
             let curr_node = leaves[idx].clone();
             let guard = curr_node.read().unwrap();
             let leaf_node = guard.as_leaf_node();
@@ -298,7 +296,7 @@ mod Test {
                         }
                         None => {
                             if test_internal_node.edges[idx].is_some() {
-                                let foo = "";
+                                let _foo = "";
                             }
                             assert_eq!(test_internal_node.edges[idx].is_none(), true);
                         }
@@ -312,7 +310,7 @@ mod Test {
     }
 
     fn assert_tree<K: NodeKey>(tree: &BTree<K>, test_node: &TestNode<K>) {
-        let root = tree.root.borrow().clone().read().unwrap().clone().unwrap();
+        let root = tree.root.borrow().read().unwrap().clone().unwrap();
         assert_node(root, test_node);
     }
 
@@ -431,20 +429,11 @@ mod Test {
     }
 
     mod split {
-        use std::{borrow::Borrow, cell::RefCell, rc::Rc};
+        
 
-        use crate::latch_manager::{
-            latch_interval_btree::{BTree, LeafNode, Node},
-            latch_interval_btree_test::Test::{
-                assert_leaf_with_siblings, assert_node, find_node_and_parent_with_indices,
-                get_all_leaves, get_start_keys_from_weak_link,
-            },
-        };
+        
 
-        use super::{
-            create_test_node, create_test_tree, print_node_recursive, print_tree, TestInternalNode,
-            TestLeafNode, TestNode,
-        };
+        
 
         #[test]
         fn split_internal() {
@@ -545,11 +534,9 @@ mod Test {
     }
 
     mod insert {
-        use crate::latch_manager::latch_interval_btree::{BTree, LatchKeyGuard, Range};
+        
 
-        use super::{
-            assert_node, assert_tree, print_tree, TestInternalNode, TestLeafNode, TestNode,
-        };
+        
 
         #[test]
         fn insert_and_split() {
@@ -698,9 +685,9 @@ mod Test {
     }
 
     mod leaf_underflow {
-        use std::{cell::RefCell, sync::RwLock};
+        
 
-        use crate::latch_manager::latch_interval_btree::{LatchWaiters, LeafNode};
+        
 
         #[test]
         fn underflows() {
@@ -720,9 +707,7 @@ mod Test {
 
     mod delete {
         mod core_delete {
-            use crate::latch_manager::latch_interval_btree_test::Test::{
-                assert_tree, create_test_tree, print_tree, TestInternalNode, TestLeafNode, TestNode,
-            };
+            
 
             #[test]
             fn internal_node_stealing_from_left_sibling_3_layers() {
@@ -987,17 +972,12 @@ mod Test {
         }
 
         mod leaf_stealing {
-            use crate::latch_manager::latch_interval_btree::Node;
+            
 
             mod has_spare_keys {
-                use std::{cell::RefCell, sync::RwLock};
+                
 
-                use crate::latch_manager::{
-                    latch_interval_btree::{LatchWaiters, LeafNode},
-                    latch_interval_btree_test::Test::{
-                        assert_tree, create_test_tree, TestInternalNode, TestLeafNode, TestNode,
-                    },
-                };
+                
 
                 #[test]
                 fn internal_node() {}
@@ -1096,10 +1076,7 @@ mod Test {
             }
 
             mod stealing_core {
-                use crate::latch_manager::latch_interval_btree_test::Test::{
-                    assert_tree, create_test_tree, print_tree, TestInternalNode, TestLeafNode,
-                    TestNode,
-                };
+                
 
                 #[test]
                 fn leaf_steals_left_sibling() {
@@ -1227,10 +1204,7 @@ mod Test {
         }
 
         mod internal_node_stealing {
-            use crate::latch_manager::latch_interval_btree_test::Test::{
-                assert_tree, create_test_tree, find_node_and_parent_with_indices, TestInternalNode,
-                TestLeafNode, TestNode,
-            };
+            
 
             #[test]
             fn simple_steal_from_left_sibling() {
@@ -1393,10 +1367,7 @@ mod Test {
 
     mod merge {
         mod internal_node {
-            use crate::latch_manager::latch_interval_btree_test::Test::{
-                assert_tree, create_test_tree, find_node_and_parent_with_indices, TestInternalNode,
-                TestLeafNode, TestNode,
-            };
+            
 
             #[test]
             fn merge_with_left() {
@@ -1524,10 +1495,7 @@ mod Test {
         }
 
         mod leaf {
-            use crate::latch_manager::latch_interval_btree_test::Test::{
-                assert_tree, create_test_tree, find_node_and_parent_with_indices, print_tree,
-                TestInternalNode, TestLeafNode, TestNode,
-            };
+            
 
             #[test]
             fn merge_with_left_leaf() {

--- a/src/latch_manager/latch_manager.rs
+++ b/src/latch_manager/latch_manager.rs
@@ -1,4 +1,4 @@
-use std::sync::mpsc::{Receiver, Sender};
+
 
 use rand::Rng;
 use tokio::time::{self, Duration};
@@ -7,7 +7,6 @@ use crate::execute::request::SpanSet;
 
 use super::{
     latch_interval_btree::{BTree, LatchKeyGuard, NodeKey, Range},
-    spanset::Span,
 };
 
 pub struct LatchManager<K: NodeKey> {
@@ -89,11 +88,11 @@ impl<K: NodeKey> LatchManager<K> {
 
 mod Test {
     mod Acquire {
-        use std::sync::Arc;
+        
 
-        use tokio::time::{self, sleep, Duration};
+        
 
-        use crate::latch_manager::{latch_interval_btree::Range, latch_manager::LatchManager};
+        
 
         #[tokio::test]
         async fn test_select() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@ mod storage;
 mod timestamp_oracle;
 mod txn_wait;
 
-use rocksdb::{Options, DB};
-use serde::de::Error;
+use rocksdb::{DB};
+
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StorageError {

--- a/src/llrb/llrb.rs
+++ b/src/llrb/llrb.rs
@@ -1,9 +1,6 @@
 use std::{
-    borrow::{Borrow, BorrowMut},
-    cell::{Ref, RefCell, RefMut},
     cmp::Ordering,
     fmt,
-    rc::Rc,
 };
 
 pub trait NodeKey: std::fmt::Debug + Clone + Eq + PartialOrd + Ord {}
@@ -222,7 +219,7 @@ impl<K: NodeKey, V: NodeValue> RbTree<K, V> {
                 value,
                 prev,
             ));
-            let mut parent_node = &mut self.nodes[prev];
+            let parent_node = &mut self.nodes[prev];
             let ord = parent_node.start_key.cmp(&start_key.clone());
             match ord {
                 Ordering::Less => {
@@ -268,7 +265,7 @@ impl<K: NodeKey, V: NodeValue> RbTree<K, V> {
     pub fn left_rotate(&mut self, k: usize) {
         let right = self.nodes[k].right_node;
         if right == NIL {
-            let foo = "";
+            let _foo = "";
         }
         let right_left = self.nodes[right].left_node;
         let parent = self.nodes[k].parent_node;
@@ -511,14 +508,14 @@ impl NodeKey for i32 {}
 impl NodeValue for i32 {}
 
 mod Test {
-    use std::{cell::RefCell, rc::Rc};
+    
 
-    use crate::llrb::llrb::{Node, TreeColor};
+    
 
-    use super::RbTree;
+    
 
     mod insert_node {
-        use crate::llrb::llrb::RbTree;
+        
 
         #[test]
         fn insert_into_empty_tree() {
@@ -582,7 +579,7 @@ mod Test {
     }
 
     mod left_rotate {
-        use crate::llrb::llrb::{Node, RbTree, TreeColor};
+        
 
         #[test]
         fn left_rotate_on_root() {
@@ -648,7 +645,7 @@ mod Test {
     }
 
     mod right_rotate {
-        use crate::llrb::llrb::{Node, RbTree, TreeColor};
+        
 
         #[test]
         fn simple_right_rotate_on_root() {

--- a/src/lock_table/lock_table.rs
+++ b/src/lock_table/lock_table.rs
@@ -116,7 +116,7 @@ impl LockTable {
         request_sender: Arc<Sender<TaskQueueRequest>>,
         store: Arc<KVStore>,
     ) -> Self {
-        let cloned_sender = request_sender.clone();
+        let _cloned_sender = request_sender.clone();
 
         LockTable {
             locks: RwLock::new(HashMap::new()),
@@ -254,7 +254,7 @@ impl LockTable {
         let mut rx = lg.wait_done_receiver.lock().await;
 
         // TODO: Random
-        let duration: u64 = rand::thread_rng().gen_range(500..1000);
+        let _duration: u64 = rand::thread_rng().gen_range(500..1000);
         let sleep = time::sleep(Duration::from_millis(1000));
         tokio::pin!(sleep);
 
@@ -583,7 +583,7 @@ impl LockState {
 
         let lg = guard.as_ref();
 
-        let (lg_txn_id, lg_read_timestamp, lg_write_timestamp) =
+        let (lg_txn_id, lg_read_timestamp, _lg_write_timestamp) =
             Txn::get_txn_properties(lg.txn.clone());
         let is_reserved = self.reservation.read().unwrap().is_some();
 

--- a/src/lock_table/scratch_test.rs
+++ b/src/lock_table/scratch_test.rs
@@ -1,5 +1,5 @@
 mod Test {
-    use tokio::time::{self, sleep, Duration};
+    use tokio::time::{sleep, Duration};
 
     // #[tokio::test]
     async fn try_join() {

--- a/src/storage/mvcc.rs
+++ b/src/storage/mvcc.rs
@@ -7,9 +7,8 @@ use super::{
     mvcc_iterator::{IterOptions, MVCCIterator},
     mvcc_key::{create_intent_key, decode_mvcc_key, MVCCKey},
     mvcc_scanner::MVCCScanner,
-    serialized_to_value,
     storage::Storage,
-    txn::{TransactionStatus, Txn, TxnIntent, TxnMetadata, TxnRecord, UncommittedValue},
+    txn::{TransactionStatus, TxnIntent, TxnMetadata, TxnRecord, UncommittedValue},
     Key, Value,
 };
 

--- a/src/storage/mvcc_iterator.rs
+++ b/src/storage/mvcc_iterator.rs
@@ -5,7 +5,7 @@ use serde::de::DeserializeOwned;
 
 use super::{
     boxed_byte_to_byte_vec,
-    mvcc_key::{decode_mvcc_key, encode_mvcc_key, MVCCKey},
+    mvcc_key::{decode_mvcc_key, MVCCKey},
     storage::Storage,
     Value,
 };
@@ -16,7 +16,7 @@ pub struct IterOptions {
 
 pub type KVBytes = (Box<[u8]>, Box<[u8]>);
 
-pub fn new_mvcc_iterator<'a>(iter_options: IterOptions, db: rocksdb::DB) -> MVCCIterator<'a> {
+pub fn new_mvcc_iterator<'a>(_iter_options: IterOptions, _db: rocksdb::DB) -> MVCCIterator<'a> {
     // RocksDBIterator { db: db, it: () }
     todo!()
 }
@@ -151,19 +151,11 @@ impl<'a> MVCCIterator<'a> {
 }
 
 mod tests {
-    use rocksdb::{IteratorMode, DB};
+    
 
-    use crate::{
-        hlc::timestamp::{get_intent_timestamp, Timestamp},
-        storage::{
-            mvcc,
-            mvcc_key::{encode_mvcc_key, MVCCKey},
-            storage::Storage,
-            str_to_key,
-        },
-    };
+    
 
-    use super::{IterOptions, MVCCIterator};
+    
 
     #[test]
     fn test_current_key_and_current_value() {
@@ -254,15 +246,7 @@ mod tests {
     }
 
     mod test_seek_ge {
-        use crate::{
-            hlc::timestamp::Timestamp,
-            storage::{
-                mvcc_iterator::{IterOptions, MVCCIterator},
-                mvcc_key::MVCCKey,
-                storage::Storage,
-                str_to_key,
-            },
-        };
+        
 
         #[test]
         fn test_multiple_timestamps_with_same_prefix() {

--- a/src/timestamp_oracle/oracle.rs
+++ b/src/timestamp_oracle/oracle.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::RwLock};
+use std::{sync::RwLock};
 
 use uuid::Uuid;
 
@@ -8,7 +8,7 @@ use crate::{
     interval::interval_tree::IntervalTree,
     latch_manager::latch_interval_btree::Range,
     llrb::llrb::{NodeKey, NodeValue},
-    storage::{Key, Value},
+    storage::{Key},
 };
 
 #[derive(Clone)]
@@ -85,7 +85,7 @@ impl TimestampOracle {
         let mut max: Option<(Timestamp, Option<Uuid>)> = None;
         for range_value in overlaps.iter() {
             match max {
-                Some((curr_timestamp, txn_id)) => {
+                Some((curr_timestamp, _txn_id)) => {
                     let ord = curr_timestamp.cmp(&range_value.value.timestamp);
                     match ord {
                         std::cmp::Ordering::Less => {
@@ -107,10 +107,7 @@ impl TimestampOracle {
 mod Test {
 
     mod get_max_timestamp {
-        use crate::{
-            hlc::timestamp::Timestamp, storage::str_to_key,
-            timestamp_oracle::oracle::TimestampOracle,
-        };
+        
 
         #[test]
         fn test_overlap() {

--- a/src/txn_wait/txn_wait_queue.rs
+++ b/src/txn_wait/txn_wait_queue.rs
@@ -15,12 +15,10 @@ use uuid::Uuid;
 
 use crate::{
     db::{
-        db::InternalDB,
         request_queue::{
             AbortTxnQueueRequest, QueueResponseUnion, TaskQueueRequest, TaskQueueRequestUnion,
         },
     },
-    execute::executor::Executor,
     storage::{mvcc::KVStore, txn::TransactionStatus},
 };
 
@@ -177,7 +175,7 @@ impl TxnWaitQueue {
     /**
      * Removes the waitingPush from its pushee's waiting_pushes
      */
-    fn dequeue(&self, waiting_push: WaitingPush, pushee_txn_id: Uuid) {
+    fn dequeue(&self, _waiting_push: WaitingPush, _pushee_txn_id: Uuid) {
         todo!()
     }
 


### PR DESCRIPTION
Running `cargo build` on latest master results in 155 warnings with message as:
```
warning: `rustyDB` (lib) generated 155 warnings (run `cargo fix --lib -p rustyDB` to apply 102 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 1m 19s
```

Post running `cargo fix --lib -p rustyDB`, output of `cargo build` is:
```
warning: `rustyDB` (lib) generated 53 warnings
``` 