### PR TITLE
Added test_helper for db path creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,8 @@ protobuf-codegen = "3.2.0"
 tokio = { version = "1.26.0", features = ["full"] }
 rand = "0.8.5"
 async-trait = "0.1.68"
+tempfile = "3.7.0"
 
 [build-dependencies]
 protobuf = "3.2.0"
 protobuf-codegen = "3.2.0"
-
-[dev-dependencies]
-tempfile = "3.7.0"

--- a/src/db/db_test.rs
+++ b/src/db/db_test.rs
@@ -1,26 +1,15 @@
 #[cfg(test)]
 mod test {
 
-    use tempfile::tempdir;
-
-    // Helper function to create tempoary directory for new database creation.
-    // This returns the path for newly created directory.
-    fn create_temp_dir() -> String {
-        tempdir()
-            .map(|temp_dir| temp_dir.path().to_str().unwrap_or_default().to_string())
-            .unwrap_or_else(|err| {
-                eprintln!("Failed to create temporary directory: {}", err);
-                String::new()
-            })
-    }
-
     // simple tests that involve writes and reads
     #[cfg(test)]
     mod single_txn_simple_test {
-        use super::create_temp_dir;
         use std::sync::Arc;
 
-        use crate::db::db::{Timestamp, DB};
+        use crate::{
+            db::db::{Timestamp, DB},
+            helpers::test_helpers::create_temp_dir,
+        };
 
         #[tokio::test]
         async fn two_writes_with_different_keys() {
@@ -46,7 +35,6 @@ mod test {
 
     #[cfg(test)]
     mod transaction_conflicts {
-        use super::create_temp_dir;
         // A read running into an uncommitted intent with a lower timestamp will wait for the
         // earlier transaction
 
@@ -61,9 +49,9 @@ mod test {
             mod uncommitted_intent_has_lower_timestamp {
                 use std::sync::Arc;
 
-                use crate::db::{
-                    db::{Timestamp, DB},
-                    db_test::test::create_temp_dir,
+                use crate::{
+                    db::db::{Timestamp, DB},
+                    helpers::test_helpers::create_temp_dir,
                 };
 
                 #[tokio::test]
@@ -95,9 +83,9 @@ mod test {
             mod uncommitted_intent_has_higher_timestamp {
                 use std::sync::Arc;
 
-                use crate::db::{
-                    db::{Timestamp, DB},
-                    db_test::test::create_temp_dir,
+                use crate::{
+                    db::db::{Timestamp, DB},
+                    helpers::test_helpers::create_temp_dir,
                 };
 
                 #[tokio::test]
@@ -125,8 +113,10 @@ mod test {
 
                 use crate::db::db::{CommitTxnResult, Timestamp, DB};
 
-                use crate::db::db_test::test::create_temp_dir;
-                use crate::hlc::timestamp::Timestamp as HLCTimestamp;
+                use crate::{
+                    helpers::test_helpers::create_temp_dir,
+                    hlc::timestamp::Timestamp as HLCTimestamp,
+                };
 
                 #[tokio::test]
                 async fn write_waits_for_uncommitted_write() {
@@ -173,9 +163,9 @@ mod test {
             mod run_into_committed_intent {
                 use std::sync::Arc;
 
-                use crate::db::{
-                    db::{CommitTxnResult, Timestamp, DB},
-                    db_test::test::create_temp_dir,
+                use crate::{
+                    db::db::{CommitTxnResult, Timestamp, DB},
+                    helpers::test_helpers::create_temp_dir,
                 };
 
                 #[tokio::test]
@@ -228,9 +218,9 @@ mod test {
         mod read_write {
             use std::sync::Arc;
 
-            use crate::db::{
-                db::{CommitTxnResult, Timestamp, DB},
-                db_test::test::create_temp_dir,
+            use crate::{
+                db::db::{CommitTxnResult, Timestamp, DB},
+                helpers::test_helpers::create_temp_dir,
             };
 
             #[tokio::test]
@@ -272,9 +262,9 @@ mod test {
         mod read_refresh_success {
             use std::sync::Arc;
 
-            use crate::db::{
-                db::{CommitTxnResult, Timestamp, DB},
-                db_test::test::create_temp_dir,
+            use crate::{
+                db::db::{CommitTxnResult, Timestamp, DB},
+                helpers::test_helpers::create_temp_dir,
             };
 
             #[tokio::test]
@@ -314,9 +304,9 @@ mod test {
         mod read_refresh_failure {
             use std::sync::Arc;
 
-            use crate::db::{
-                db::{CommitTxnResult, Timestamp, DB},
-                db_test::test::create_temp_dir,
+            use crate::{
+                db::db::{CommitTxnResult, Timestamp, DB},
+                helpers::test_helpers::create_temp_dir,
             };
 
             #[tokio::test]
@@ -360,8 +350,10 @@ mod test {
 
     #[cfg(test)]
     mod abort_txn {
-        use super::create_temp_dir;
-        use crate::db::db::{Timestamp, DB};
+        use crate::{
+            db::db::{Timestamp, DB},
+            helpers::test_helpers::create_temp_dir,
+        };
 
         #[tokio::test]
         async fn read_write_after_abort_transaction() {
@@ -387,11 +379,11 @@ mod test {
 
     #[cfg(test)]
     mod deadlock {
-        use super::create_temp_dir;
         use std::sync::Arc;
 
         use crate::{
             db::db::{CommitTxnResult, Timestamp, DB},
+            helpers::test_helpers::create_temp_dir,
             storage::str_to_key,
         };
 
@@ -500,10 +492,12 @@ mod test {
 
     #[cfg(test)]
     mod run_txn {
-        use super::create_temp_dir;
         use std::sync::Arc;
 
-        use crate::db::db::{Timestamp, DB};
+        use crate::{
+            db::db::{Timestamp, DB},
+            helpers::test_helpers::create_temp_dir,
+        };
 
         #[tokio::test]
         async fn reading_its_txn_own_write() {

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod test_helpers;

--- a/src/helpers/test_helpers.rs
+++ b/src/helpers/test_helpers.rs
@@ -1,0 +1,12 @@
+use tempfile::tempdir;
+
+// Helper function to create tempoary directory for new database creation.
+// This returns the path for newly created directory.
+pub fn create_temp_dir() -> String {
+    tempdir()
+        .map(|temp_dir| temp_dir.path().to_str().unwrap_or_default().to_string())
+        .unwrap_or_else(|err| {
+            eprintln!("Failed to create temporary directory: {}", err);
+            String::new()
+        })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod concurrency;
 pub mod db;
 pub mod execute;
+pub mod helpers;
 pub mod hlc;
 mod interval;
 mod latch_manager;

--- a/src/lock_table/lock_table.rs
+++ b/src/lock_table/lock_table.rs
@@ -129,13 +129,15 @@ impl LockTable {
     pub fn new_with_defaults() -> Self {
         use tokio::sync::mpsc;
 
+        use crate::helpers::test_helpers::create_temp_dir;
+
         let (sender, _receiver) = mpsc::channel::<TaskQueueRequest>(1);
         LockTable {
             locks: RwLock::new(HashMap::new()),
             txn_map: Arc::new(RwLock::new(HashMap::new())),
             txn_wait_queue: TxnWaitQueue::new(
                 Arc::new(sender),
-                Arc::new(KVStore::new_random_path()),
+                Arc::new(KVStore::new_cleaned(&create_temp_dir())),
             ),
         }
     }

--- a/src/storage/mvcc.rs
+++ b/src/storage/mvcc.rs
@@ -54,12 +54,6 @@ impl KVStore {
         }
     }
 
-    pub fn new_random_path() -> Self {
-        let string = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
-
-        KVStore::new_cleaned(&format!("./tmp/{}", string))
-    }
-
     pub fn new(path: &str) -> Self {
         KVStore {
             storage: Storage::new(path),

--- a/src/storage/mvcc_iterator.rs
+++ b/src/storage/mvcc_iterator.rs
@@ -153,6 +153,7 @@ impl<'a> MVCCIterator<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{
+        helpers::test_helpers::create_temp_dir,
         hlc::timestamp::{get_intent_timestamp, Timestamp},
         storage::{
             mvcc_iterator::{IterOptions, MVCCIterator},
@@ -164,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_current_key_and_current_value() {
-        let storage = Storage::new_random_path();
+        let storage = Storage::new_cleaned(&create_temp_dir());
         let mvcc_key = MVCCKey::new(
             str_to_key("hello"),
             Timestamp {
@@ -190,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_order_of_iteration_with_intent_timestamp() {
-        let storage = Storage::new_random_path();
+        let storage = Storage::new_cleaned(&create_temp_dir());
         let key = "hello";
 
         let mvcc_key_2 = MVCCKey::new(
@@ -253,6 +254,7 @@ mod tests {
     #[cfg(test)]
     mod test_seek_ge {
         use crate::{
+            helpers::test_helpers::create_temp_dir,
             hlc::timestamp::Timestamp,
             storage::{
                 mvcc_iterator::{IterOptions, MVCCIterator},
@@ -264,7 +266,7 @@ mod tests {
 
         #[test]
         fn test_multiple_timestamps_with_same_prefix() {
-            let storage = Storage::new_random_path();
+            let storage = Storage::new_cleaned(&create_temp_dir());
             let key = "foo";
             let mvcc_key_1 = MVCCKey::new(
                 str_to_key(key),
@@ -315,7 +317,7 @@ mod tests {
 
         #[test]
         fn empty_db() {
-            let storage = Storage::new_random_path();
+            let storage = Storage::new_cleaned(&create_temp_dir());
             let key = "foo";
             let mvcc_key_1 = MVCCKey::new(
                 str_to_key(key),

--- a/src/storage/mvcc_scanner_test.rs
+++ b/src/storage/mvcc_scanner_test.rs
@@ -5,6 +5,7 @@ mod tests {
         use uuid::Uuid;
 
         use crate::{
+            helpers::test_helpers::create_temp_dir,
             hlc::timestamp::Timestamp,
             storage::{
                 mvcc::KVStore,
@@ -19,7 +20,7 @@ mod tests {
 
         #[test]
         fn no_intent_and_no_end_key() {
-            let storage = Storage::new_random_path();
+            let storage = Storage::new_cleaned(&create_temp_dir());
             let key = "foo";
             let mvcc_key_1 = MVCCKey::new(
                 str_to_key(key),
@@ -63,7 +64,7 @@ mod tests {
 
         #[test]
         fn intent_found() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
             let timestamp = Timestamp::new(12, 0);
             let txn_id = Uuid::new_v4();
             let txn = Txn::new_link(txn_id, timestamp);
@@ -101,6 +102,7 @@ mod tests {
     #[cfg(test)]
     mod advance_to_next_key {
         use crate::{
+            helpers::test_helpers::create_temp_dir,
             hlc::timestamp::Timestamp,
             storage::{
                 mvcc::KVStore,
@@ -113,7 +115,7 @@ mod tests {
 
         #[test]
         fn advances_to_next_key() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
             let first_key = "apple";
             let first_key_timestamp1 = Timestamp::new(2, 3);
             let first_key_timestamp2 = Timestamp::new(3, 0);
@@ -155,7 +157,7 @@ mod tests {
 
         #[test]
         fn there_is_no_next_key() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
             let iterator = MVCCIterator::new(&kv_store.storage, IterOptions { prefix: true });
             let scanner_timestamp = Timestamp {
                 logical_time: 3,
@@ -178,6 +180,7 @@ mod tests {
         use uuid::Uuid;
 
         use crate::{
+            helpers::test_helpers::create_temp_dir,
             hlc::timestamp::Timestamp,
             storage::{
                 mvcc::KVStore,
@@ -191,7 +194,7 @@ mod tests {
 
         #[test]
         fn multiple_timestamps_for_same_keys() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
 
             let scan_timestamp = Timestamp::new(12, 3);
 
@@ -255,7 +258,7 @@ mod tests {
 
         #[test]
         fn multiple_intents() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
             let txn_id = Uuid::new_v4();
             let transaction_timestamp = Timestamp::new(12, 0);
             let txn = Txn::new_link(txn_id, transaction_timestamp);

--- a/src/storage/mvcc_test.rs
+++ b/src/storage/mvcc_test.rs
@@ -3,6 +3,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::{
+        helpers::test_helpers::create_temp_dir,
         hlc::timestamp::Timestamp,
         storage::{
             mvcc::KVStore,
@@ -12,7 +13,7 @@ mod tests {
 
     #[test]
     fn create_pending_transaction_record() -> () {
-        let kv_store = KVStore::new_random_path();
+        let kv_store = KVStore::new_cleaned(&create_temp_dir());
         let transaction_id = Uuid::new_v4();
         let write_timestamp = Timestamp {
             wall_time: 0,
@@ -36,6 +37,7 @@ mod tests {
         use uuid::Uuid;
 
         use crate::{
+            helpers::test_helpers::create_temp_dir,
             hlc::timestamp::Timestamp,
             storage::{
                 mvcc::KVStore, mvcc_iterator::IterOptions, mvcc_key::MVCCKey, str_to_key, txn::Txn,
@@ -44,7 +46,7 @@ mod tests {
 
         #[test]
         fn put_with_transaction() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
             let key = "foo";
             let txn1_id = Uuid::new_v4();
 
@@ -66,7 +68,7 @@ mod tests {
 
         #[test]
         fn write_intent_error() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
             let key = "foo";
             let txn1_id = Uuid::new_v4();
 
@@ -102,6 +104,7 @@ mod tests {
         use uuid::Uuid;
 
         use crate::{
+            helpers::test_helpers::create_temp_dir,
             hlc::timestamp::Timestamp,
             storage::{
                 mvcc::{KVStore, MVCCGetParams},
@@ -113,7 +116,7 @@ mod tests {
 
         #[test]
         fn get_key_with_multiple_timestamps() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
             let read_timestamp = Timestamp::new(10, 10);
 
             let key1 = str_to_key("apple");
@@ -159,7 +162,7 @@ mod tests {
 
         #[test]
         fn get_intent() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
             let key = "foo";
             let txn1_id = Uuid::new_v4();
 
@@ -201,6 +204,7 @@ mod tests {
         use uuid::Uuid;
 
         use crate::{
+            helpers::test_helpers::create_temp_dir,
             hlc::timestamp::Timestamp,
             storage::{
                 mvcc::KVStore,
@@ -212,7 +216,7 @@ mod tests {
 
         #[test]
         fn resolve_intent_with_higher_timestamp() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
             let uncommitted_timestamp = Timestamp::new(10, 10);
 
             let key = str_to_key("apple");
@@ -259,7 +263,7 @@ mod tests {
 
         #[test]
         fn resolve_intent_owned_by_another_txn() {
-            let kv_store = KVStore::new_random_path();
+            let kv_store = KVStore::new_cleaned(&create_temp_dir());
             let uncommitted_timestamp = Timestamp::new(10, 10);
 
             let key = str_to_key("apple");

--- a/src/storage/storage.rs
+++ b/src/storage/storage.rs
@@ -37,11 +37,6 @@ impl Storage {
         Storage { db }
     }
 
-    pub fn new_random_path() -> Storage {
-        let string = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
-        Storage::new_cleaned(&format!("./tmp/{}", string))
-    }
-
     // path example: "./tmp/data";
     pub fn new_cleaned(path: &str) -> Storage {
         if Path::new(path).exists() {
@@ -221,6 +216,7 @@ mod Test {
     use serde::{Deserialize, Serialize};
 
     use crate::{
+        helpers::test_helpers::create_temp_dir,
         hlc::timestamp::Timestamp,
         storage::{mvcc_key::MVCCKey, str_to_key},
     };
@@ -234,7 +230,7 @@ mod Test {
 
     #[test]
     fn put_mvcc() {
-        let storage = Storage::new_random_path();
+        let storage = Storage::new_cleaned(&create_temp_dir());
         let mvcc_key = MVCCKey::new(
             str_to_key("hello"),
             Timestamp {
@@ -253,6 +249,7 @@ mod Test {
     mod storage_order {
 
         use crate::{
+            helpers::test_helpers::create_temp_dir,
             hlc::timestamp::Timestamp,
             storage::{
                 mvcc_iterator::MVCCIterator, mvcc_key::MVCCKey, storage::Storage, str_to_key,
@@ -261,7 +258,7 @@ mod Test {
 
         #[test]
         fn check_order_no_intent() {
-            let storage = Storage::new_random_path();
+            let storage = Storage::new_cleaned(&create_temp_dir());
             let first_mvcc_key = MVCCKey::new(str_to_key("a"), Timestamp::new(1, 0));
             let second_mvcc_key = MVCCKey::new(str_to_key("a"), Timestamp::new(2, 0));
 
@@ -283,7 +280,7 @@ mod Test {
 
         #[test]
         fn check_order_intent() {
-            let storage = Storage::new_random_path();
+            let storage = Storage::new_cleaned(&create_temp_dir());
             let key = "a";
             let intent_key = MVCCKey::create_intent_key_with_str(key);
             let non_intent_key = MVCCKey::new(str_to_key(key), Timestamp::new(2, 0));


### PR DESCRIPTION
This fixes #12 under all tests. Also this centralizes the helper function to create temporary directory across all tests in a helper file `test_helpers.rs`

Once this change is merged, running tests across multiple threads will work without creating any temporary directories locally. `tempdir` takes care of creating & cleanup within the lifeline of a test.